### PR TITLE
Add datetime formatting for 1 hour or more.

### DIFF
--- a/i3blockstimerthing.py
+++ b/i3blockstimerthing.py
@@ -75,9 +75,12 @@ seconds_count, state = read_timer()
 
 
 def format_time(seconds_count):
-    minutes = str(int(seconds_count / 60))
-    seconds = str(int(seconds_count % 60)).zfill(2)
-    return f"{minutes}:{seconds}"
+    if seconds_count < 3600:
+        minutes = str(int(seconds_count / 60))
+        seconds = str(int(seconds_count % 60)).zfill(2)
+        return f"{minutes}:{seconds}"
+    else:
+        return str(timedelta(seconds=seconds_count))
 
 if state == "paused":
     icon = "⏸️ "


### PR DESCRIPTION
Thanks for the neat timer :slightly_smiling_face: . I'm new to i3 (loving it), and not a python programmer, but this change seems straightforward and seems to work fine for me.

I don't see any reason why someone would prefer to see "163:00" to "2:43:00", but let me know if I'm mistaken.